### PR TITLE
Typo in documentation: REPEAT is not a valid filter mode, should be LINEAR

### DIFF
--- a/src/texture.js
+++ b/src/texture.js
@@ -4,7 +4,7 @@
 //
 // The arguments `width` and `height` give the size of the texture in texels.
 // WebGL texture dimensions must be powers of two unless `filter` is set to
-// either `gl.NEAREST` or `gl.REPEAT` and `wrap` is set to `gl.CLAMP_TO_EDGE`
+// either `gl.NEAREST` or `gl.LINEAR` and `wrap` is set to `gl.CLAMP_TO_EDGE`
 // (which they are by default).
 //
 // Texture parameters can be passed in via the `options` argument.


### PR DESCRIPTION
Had some issues with textures and noticed a potentially confusing bug in the Texture constructor docs. Thanks for the great library!
