### PR TITLE
Chrome 29 needs to get OES_texture_float_linear explicitly.

### DIFF
--- a/tests/gpulightmap.html
+++ b/tests/gpulightmap.html
@@ -31,6 +31,10 @@ if (!gl.getExtension('OES_texture_float')) {
   document.write('This demo requires the OES_texture_float extension to run');
   throw 'not supported';
 }
+if (!gl.getExtension('OES_texture_float_linear')) {
+  document.write('This demo requires the OES_texture_float_linear extension to run');
+  throw 'not supported';
+}
 
 var depthMap = new GL.Texture(1024, 1024, { format: gl.RED });
 var depthShader = new GL.Shader('\


### PR DESCRIPTION
Thank you for your great work.

I tried lightgl.js's demos and found that gpulightmap doesn't work on Chrome(29) though it works well on FireFox.
The reason was the lack of OES_texture_float_linear, so I fixed it.
