### PR TITLE
adding support for int type in shaders

### DIFF
--- a/src/shader.js
+++ b/src/shader.js
@@ -264,7 +264,16 @@ Shader.prototype = {
       } else {
         gl.drawArrays(mode, 0, length);
       }
-    }
+    }    
+    
+    // release any buffers;
+    // if the shader is switched, some attributes could still be linked to buffers, causing
+    // GL_INVALID_OPERATION : glDrawArrays: attempt to access out of range vertices in attribute [location]:
+    // see http://stackoverflow.com/questions/12427880/is-it-important-to-call-gldisablevertexattribarray
+    gl.bindBuffer(gl.ARRAY_BUFFER, null);
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, null);
+    for (var attribute in vertexBuffers)
+      gl.disableVertexAttribArray(this.attributes[attribute]);
 
     return this;
   }


### PR DESCRIPTION
Currently, if a shader has a uniform of type int, an error will result (GL_INVALID_OPERATION : glUniform1fv: wrong uniform function for type) since all individual values passed to GL.Shaders.uniforms() are assumed to be floats.

I'm overloading on isSampler to make the initial decision.  Note that 'isSampler' is now technically 'isIntUniform', but I'll leave that naming convention to you.

This is my first pull request, so let me know if this is helpful or what I should be doing in the future! :)  Thanks for this helpful library.
