### PR TITLE
Switch gl_TexCoord to vec2 in vertex shader header

### DIFF
--- a/src/shader.js
+++ b/src/shader.js
@@ -53,7 +53,7 @@ function Shader(vertexSource, fragmentSource) {
   ';
   var vertexHeader = header + '\
     attribute vec4 gl_Vertex;\
-    attribute vec4 gl_TexCoord;\
+    attribute vec2 gl_TexCoord;\
     attribute vec3 gl_Normal;\
     attribute vec4 gl_Color;\
     vec4 ftransform() {\


### PR DESCRIPTION
I'm perhaps misunderstanding the code here, but it seems to me like gl_TexCoord should be a vec2, given mesh example code that looks like this:

```
mesh.coords = [[0, 0], [1, 0], [0, 1], [1, 1]];
```