### PR TITLE
Allow passing raw data to Texture constructor

### DIFF
--- a/src/texture.js
+++ b/src/texture.js
@@ -54,7 +54,7 @@ function Texture(width, height, options) {
   gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, minFilter);
   gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, options.wrap || options.wrapS || gl.CLAMP_TO_EDGE);
   gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, options.wrap || options.wrapT || gl.CLAMP_TO_EDGE);
-  gl.texImage2D(gl.TEXTURE_2D, 0, this.format, width, height, 0, this.format, this.type, null);
+  gl.texImage2D(gl.TEXTURE_2D, 0, this.format, width, height, 0, this.format, this.type, options.data || null);
 }
 
 var framebuffer;


### PR DESCRIPTION
This facilitates being able to pass in data for use in GPGPU applications.

This would allow, e.g. setting initial data for a simulation where simulation
state is stored in textures.

Usage would like like:

```javascript
var texture = new GL.Texture(2, 2, new Float32Array([1, 2, 3, 4]));
```